### PR TITLE
Improve upgrade notes and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Follow the installation instructions in the [Getting Started](https://unsaged.co
 
 ## 🚀 Upgrading unSAGED
 
-On November 13th, 2023, we released a major update to unSAGED, which required a database table columns update. If you are upgrading from a version of unSAGED released before this date, you will need to run the [Upgrade Script](./db/UpgradeScript.sql) in the [Supabase SQL editor](https://app.supabase.com/project/_/sql).
+* On November 13th, 2023, we released a major update to unSAGED, which introduced more settings to the conversation. It requires that you update some database table columns. If you are upgrading from a version of unSAGED released before this date, you will need to run the [Upgrade Script](./packages/unsaged/db/UpgradeScript.sql) in the [Supabase SQL editor](https://app.supabase.com/project/_/sql).
+* On November 16th, 2023, we released a major update to unSAGED, which converts this repo into monorepo to support the documentation website. It requires that you change a setting in your Vercel project, if you have one. If you do have one, you need to set `packages/unsaged` as the [Root Directory](https://vercel.com/docs/deployments/configure-a-build#root-directory) in your Vercel project's settings.
 
 ## 📝 License
 

--- a/docs/docs/configuration/how-it-works.md
+++ b/docs/docs/configuration/how-it-works.md
@@ -7,3 +7,5 @@ sidebar_position: 1
 To make it easy to configure unSAGED, we use environment variables as the main configuration format. This allows anyone deploying unSAGED to Vercel to easily configure their instance of unSAGED without having to modify the source code.
 
 When building locally, use `packages/unsaged/.env.local` to set your environment variables. When deploying to Vercel, use the Vercel dashboard to set your environment variables.
+
+Also, set `packages/unsaged` as the [Root Directory](https://vercel.com/docs/deployments/configure-a-build#root-directory) in your Vercel project's settings.


### PR DESCRIPTION
This morning I tried to deploy the latest from `main` to my Vercel project, and it crashed. It turns out I needed to set `packages/unsaged` as the [Root Directory](https://vercel.com/docs/deployments/configure-a-build#root-directory) in my Vercel project's settings.

So I've updated the README and the docs to mention this more explicitly. And I've slightly reworded the previous upgrade advice, and fixed a link in it.

Please feel free to reword any of the text in this PR!