### PR TITLE
Resolve katex dependencies for ChatMessage.tsx

### DIFF
--- a/apps/unsaged/package.json
+++ b/apps/unsaged/package.json
@@ -34,6 +34,7 @@
     "i18next": "^22.5.1",
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.2",
+    "katex": "^0.16.9",
     "next": "^13.5.6",
     "next-auth": "^4.24.5",
     "next-axiom": "^1.1.1",


### PR DESCRIPTION
Add "katex": "^0.16.9", to resolve the following error

18.02 unsaged:build: ./components/Home/components/ChatZone/Screens/Chat/ChatMessage.tsx
18.02 unsaged:build: Module not found: Can't resolve 'katex/dist/katex.min.css'