### PR TITLE
Add keycloak auth provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 node_modules
 .pnp
 .pnp.js
+.pnpm-store/
 
 # testing
 coverage
@@ -58,3 +59,6 @@ next-env.d.ts
 
 # Localazy
 localazy.keys.json
+
+# bak
+*.bak

--- a/apps/docs/docs/auth-providers/keycloak.md
+++ b/apps/docs/docs/auth-providers/keycloak.md
@@ -1,0 +1,11 @@
+# Keycloak
+
+To set up Keycloak authentication, you will need to create a "client" in your Keycloak installation. See [NextAuth keycloak module documentation](https://next-auth.js.org/providers/keycloak) and [keycloak documentation](https://www.keycloak.org/docs/latest/server_admin/#_oidc_clients)
+
+You can enable Keycloak authentication by setting the following environment variables:
+
+```sh
+KEYCLOAK_ID=xxxx
+KEYCLOAK_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+KEYCLOAK_ISSUER=https://keycloakhost/auth/realms/yourrealm
+```

--- a/apps/web/types/auth-provider.ts
+++ b/apps/web/types/auth-provider.ts
@@ -8,6 +8,7 @@ export type AuthProvider =
   | 'github'
   | 'gitlab'
   | 'google'
+  | 'keycloak'  
   | 'okta'
   | 'reddit'
   | 'salesforce'

--- a/apps/web/utils/app/auth/constants.ts
+++ b/apps/web/utils/app/auth/constants.ts
@@ -54,6 +54,15 @@ export const GOOGLE_CLIENT_ID =
 export const GOOGLE_CLIENT_SECRET =
   dockerEnvVarFix(process.env.GOOGLE_CLIENT_SECRET) || '';
 
+export const KEYCLOAK_ID =
+  dockerEnvVarFix(process.env.KEYCLOAK_ID) || '';
+
+export const KEYCLOAK_SECRET =
+  dockerEnvVarFix(process.env.KEYCLOAK_SECRET) || '';
+
+export const KEYCLOAK_ISSUER =
+  dockerEnvVarFix(process.env.KEYCLOAK_ISSUER) || '';
+
 export const OKTA_CLIENT_ID = dockerEnvVarFix(process.env.OKTA_CLIENT_ID) || '';
 
 export const OKTA_CLIENT_SECRET =

--- a/apps/web/utils/app/auth/providers.ts
+++ b/apps/web/utils/app/auth/providers.ts
@@ -18,6 +18,9 @@ import {
   GITLAB_CLIENT_SECRET,
   GOOGLE_CLIENT_ID,
   GOOGLE_CLIENT_SECRET,
+  KEYCLOAK_ID,
+  KEYCLOAK_SECRET,
+  KEYCLOAK_ISSUER,
   OKTA_CLIENT_ID,
   OKTA_CLIENT_SECRET,
   REDDIT_CLIENT_ID,
@@ -148,6 +151,18 @@ export async function getProviders() {
         clientSecret: GOOGLE_CLIENT_SECRET!,
         authorization: authorization,
         allowDangerousEmailAccountLinking: true,
+      }),
+    );
+  }
+  if (KEYCLOAK_ID) {
+    const provider = await import('next-auth/providers/keycloak');
+    const KeycloakProvider = provider.default;
+    providers.push(
+      KeycloakProvider({
+        clientId: KEYCLOAK_ID!,
+        clientSecret: KEYCLOAK_SECRET!,
+        issuer: KEYCLOAK_ISSUER,
+        allowDangerousEmailAccountLinking: true,/*necessary*/
       }),
     );
   }


### PR DESCRIPTION
I've added this commonly used auth provider, already supported by nextauth. Only needed to add some constants and boilerplate code.